### PR TITLE
[FEAT] JWT를 이용한 회원 인증 및 로그인 유지 방식 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,13 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	// security
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+	implementation 'commons-io:commons-io:2.6'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/turnpage/domain/member/controller/AuthController.java
+++ b/src/main/java/com/example/turnpage/domain/member/controller/AuthController.java
@@ -1,11 +1,13 @@
 package com.example.turnpage.domain.member.controller;
 
+import com.example.turnpage.domain.member.dto.MemberLoginRequestDto;
 import com.example.turnpage.domain.member.dto.MemberSignupRequestDto;
 import com.example.turnpage.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -36,17 +38,7 @@ public class AuthController {
     }
 
     @PostMapping("/auth/login")
-    public @ResponseBody String loginProcess() {
+    public @ResponseBody String loginProcess(@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
         return "hi";
-    }
-
-    @GetMapping("/public")
-    public @ResponseBody String publicAccess() {
-        return "이 페이지는 모든 사용자가 이용할 수 있습니다. 당신은 로그인하지 않았을 것 같네요 :<";
-    }
-
-    @GetMapping("/private")
-    public @ResponseBody String privateAccess() {
-        return "이 페이지는 로그인된 사용자만 이용할 수 있습니다. 당신은 로그인한 상태네요? :>";
     }
 }

--- a/src/main/java/com/example/turnpage/domain/member/controller/TestController.java
+++ b/src/main/java/com/example/turnpage/domain/member/controller/TestController.java
@@ -1,0 +1,23 @@
+package com.example.turnpage.domain.member.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+    @GetMapping("/public")
+    public String publicAccess() {
+        return "이 페이지는 모든 사용자가 이용할 수 있습니다. 당신은 로그인하지 않았을 것 같네요 :<";
+    }
+
+    @GetMapping("/private")
+    public String privateAccess() {
+        return "이 페이지는 로그인된 사용자만 이용할 수 있습니다. 당신은 로그인한 상태네요? :>";
+    }
+
+    @GetMapping("/admin")
+    public String adminAccess() {
+        return "이 페이지는 관리자만 이용할 수 있습니다. 당신은 관리자네요? :O";
+    }
+}

--- a/src/main/java/com/example/turnpage/domain/member/dto/MemberLoginRequestDto.java
+++ b/src/main/java/com/example/turnpage/domain/member/dto/MemberLoginRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.turnpage.domain.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberLoginRequestDto {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/example/turnpage/domain/member/dto/MemberSignupRequestDto.java
+++ b/src/main/java/com/example/turnpage/domain/member/dto/MemberSignupRequestDto.java
@@ -14,12 +14,12 @@ public class MemberSignupRequestDto {
     private String username;
     private String password;
 
-    public Member toEntity() {
+    public Member toEntity(String role) {
         return Member.builder()
-                .name(username.split("@")[0])
+                .name(username)
                 .email(username)
                 .password(password)
-                .role("USER")
+                .role(role)
                 .inviteCode(RandomStringUtils.random(10, true, true))
                 .build();
     }

--- a/src/main/java/com/example/turnpage/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/turnpage/domain/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/turnpage/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/turnpage/domain/member/service/MemberService.java
@@ -14,14 +14,29 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
 
     public Long signup(MemberSignupRequestDto memberSignupRequestDto) {
-        // 이메일 중복 확인 코드
-        //
+        // 이메일 중복 검증 코드
+        validateEmailDuplication(memberSignupRequestDto.getUsername());
 
         String encodedPassword = passwordEncoder.encode(memberSignupRequestDto.getPassword());
         memberSignupRequestDto.setPassword(encodedPassword);
 
-        Member member = memberSignupRequestDto.toEntity();
+        // admin이 이름인 회원의 경우 권한을 ADMIN으로 설정한다
+        final Member member;
+        if (memberSignupRequestDto.getUsername().equals("admin")) {
+            member = memberSignupRequestDto.toEntity("ADMIN");
+        } else {
+            member = memberSignupRequestDto.toEntity("USER");
+        }
+
         Long memberId = memberRepository.save(member).getId();
         return memberId;
+    }
+
+    private void validateEmailDuplication(String email) {
+        boolean isDuplicated = memberRepository.existsByEmail(email);
+
+        if (isDuplicated) {
+            throw new RuntimeException(email + "은 이미 회원가입된 이메일입니다.");
+        }
     }
 }

--- a/src/main/java/com/example/turnpage/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/turnpage/global/config/SecurityConfig.java
@@ -1,21 +1,38 @@
 package com.example.turnpage.global.config;
 
-import com.example.turnpage.global.config.security.MemberDetails;
-import jakarta.servlet.http.HttpSession;
+import com.example.turnpage.global.config.security.filter.JwtAuthenticationFilter;
+import com.example.turnpage.global.config.security.filter.LoginAuthenticationFilter;
+import com.example.turnpage.global.config.security.util.JwtUtils;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.authentication.ProviderManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtils jwtUtils;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
     @Bean
     public static PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -26,26 +43,34 @@ public class SecurityConfig {
         http
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/public").permitAll()
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/error/**").permitAll()
+                        .requestMatchers("/public").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/swagger-resources/**",
                                 "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/private/**").hasRole("USER")
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
-                .formLogin(formLogin ->
-                        formLogin
-                                .usernameParameter("username")
-                                .passwordParameter("password")
-                                .loginPage("/auth/login")
-                                .defaultSuccessUrl("/")
-                                .failureUrl("/auth/login?failed=1")
-                                .permitAll()
-                );
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterAt(new LoginAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtUtils),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtils), LoginAuthenticationFilter.class);
+
 
         return http.build();
+    }
+
+    @Bean
+    static RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
+        hierarchy.setHierarchy("ROLE_ADMIN > ROLE_USER");
+        return hierarchy;
     }
 }

--- a/src/main/java/com/example/turnpage/global/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/turnpage/global/config/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.example.turnpage.global.config.security.filter;
+
+import com.example.turnpage.global.config.security.util.JwtUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String AUTHORIZATION_TYPE = "Bearer ";
+    private final JwtUtils jwtUtils;
+    public JwtAuthenticationFilter(JwtUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+    }
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization == null || !authorization.startsWith(AUTHORIZATION_TYPE)) {
+            System.out.println("토큰이 존재하지 않거나, 인증 타입이 Bearer가 아닙니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String jwt = authorization.substring(AUTHORIZATION_TYPE.length());
+        System.out.println("jwt: " + jwt);
+        if (jwtUtils.isExpired(jwt)) {
+            System.out.println("토큰이 만료되었습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = jwtUtils.getAuthentication(jwt);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/turnpage/global/config/security/filter/LoginAuthenticationFilter.java
+++ b/src/main/java/com/example/turnpage/global/config/security/filter/LoginAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.example.turnpage.global.config.security.filter;
+
+import com.example.turnpage.domain.member.dto.MemberLoginRequestDto;
+import com.example.turnpage.global.config.security.member.MemberDetails;
+import com.example.turnpage.global.config.security.util.JwtUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.io.IOUtils;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtils jwtUtils;
+    private static final AntPathRequestMatcher ANT_PATH_REQUEST_MATCHER = new AntPathRequestMatcher(
+            "/auth/login", "POST");
+    private static final String JWT_PREFIX = "Bearer ";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public LoginAuthenticationFilter(AuthenticationManager authenticationManager, JwtUtils jwtUtils) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtils = jwtUtils;
+        setRequiresAuthenticationRequestMatcher(ANT_PATH_REQUEST_MATCHER);
+    }
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        if (!request.getMethod().equals("POST")) {
+            throw new AuthenticationServiceException("Authentication method not supported: " + request.getMethod());
+        }
+
+        try {
+            // Request에서 회원의 로그인 정보 추출
+            String requestBody = IOUtils.toString(request.getReader());
+            MemberLoginRequestDto memberLoginRequestDto = objectMapper.readValue(requestBody, MemberLoginRequestDto.class);
+
+            UsernamePasswordAuthenticationToken authRequest = UsernamePasswordAuthenticationToken
+                    .unauthenticated(memberLoginRequestDto.getUsername(), memberLoginRequestDto.getPassword());
+
+            return authenticationManager.authenticate(authRequest);
+        } catch (IOException e) {
+            throw new RuntimeException("IOUtils를 활용한 request body 객체로 변환 중 문제가 발생하였습니다.");
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                            FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        // JWT 발급
+        MemberDetails memberDetails = (MemberDetails) authResult.getPrincipal();
+        String username = memberDetails.getUsername();
+        Collection<? extends GrantedAuthority> authorities = memberDetails.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority authority = iterator.next();
+        String role = authority.getAuthority();
+
+        String jwt = jwtUtils.createJwt(username, role);
+
+        response.addHeader("Authorization", JWT_PREFIX + jwt);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException, ServletException {
+        response.setStatus(401);
+    }
+}

--- a/src/main/java/com/example/turnpage/global/config/security/member/MemberDetails.java
+++ b/src/main/java/com/example/turnpage/global/config/security/member/MemberDetails.java
@@ -1,4 +1,4 @@
-package com.example.turnpage.global.config.security;
+package com.example.turnpage.global.config.security.member;
 
 import com.example.turnpage.domain.member.entity.Member;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/example/turnpage/global/config/security/member/MemberDetailsService.java
+++ b/src/main/java/com/example/turnpage/global/config/security/member/MemberDetailsService.java
@@ -1,4 +1,4 @@
-package com.example.turnpage.global.config.security;
+package com.example.turnpage.global.config.security.member;
 
 import com.example.turnpage.domain.member.entity.Member;
 import com.example.turnpage.domain.member.repository.MemberRepository;

--- a/src/main/java/com/example/turnpage/global/config/security/provider/LoginAuthenticationProvider.java
+++ b/src/main/java/com/example/turnpage/global/config/security/provider/LoginAuthenticationProvider.java
@@ -1,0 +1,17 @@
+package com.example.turnpage.global.config.security.provider;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class LoginAuthenticationProvider implements AuthenticationProvider {
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        return null;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return false;
+    }
+}

--- a/src/main/java/com/example/turnpage/global/config/security/util/JwtUtils.java
+++ b/src/main/java/com/example/turnpage/global/config/security/util/JwtUtils.java
@@ -1,0 +1,98 @@
+package com.example.turnpage.global.config.security.util;
+
+import com.example.turnpage.domain.member.entity.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtUtils {
+    private final SecretKey secretKey;
+
+    // "HMACSHA256" 알고리즘명을 저장
+    private static final String SIGNATURE_ALGORITHM = Jwts.SIG.HS256.key().build().getAlgorithm();
+    private static final String PAYLOAD_AUTHORITIES_KEY = "authorities";
+    private static final String PAYLOAD_MEMBER_ID_KEY = "memberId";
+    @Value("${jwt.access-token-validity-in-seconds}")
+    private Long expiredMs;
+
+    JwtUtils(@Value("${jwt.secret}") String secret) {
+        System.out.println("===키 바이트 길이: " + secret.getBytes(StandardCharsets.UTF_8).length + "===");
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), SIGNATURE_ALGORITHM);
+    }
+
+    // 필요한 메소드 목록
+    // JWT 발급 메소드
+    // JWT 검증 메소드
+
+    public String getUsername(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("username", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration().before(new Date());
+    }
+
+    public String createJwt(String username, String role) {
+        return Jwts.builder()
+                .claim("username", username)
+                .claim("authorities", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs * 10))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims payload = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        final List<SimpleGrantedAuthority> authorities = Arrays.stream(
+                payload.get(PAYLOAD_AUTHORITIES_KEY).toString().split(","))
+                .map(authority -> "ROLE_" + authority)
+                .map(authority -> new SimpleGrantedAuthority(authority))
+                .collect(Collectors.toList());
+
+        // 사용자 정의로 구현한 MemberDetails나 Member 엔티티 대신 기존에 제공하는 User 클래스를 사용한다.
+        // 추후 우리가 구현한 것으로 대체할 수 있는지 고려 필요함
+        final Long memberId = payload.get(PAYLOAD_MEMBER_ID_KEY, Long.class);
+        final User principal = new User(String.valueOf(memberId), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,11 @@ logging:
   pattern:
   dateformat: yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul
 
+jwt:
+  secret: SuminKangyeonarestudyingTogether
+  access-token-validity-in-seconds: 36000
+  refresh-token-validity-in-seconds:
+
 
 cloud:
   aws:


### PR DESCRIPTION

## ❗️ 이슈 번호
Closes #2 

## 📝 작업 내용
- LoginAuthenticationFilter: 아이디와 비밀번호로 로그인 요청 시, 검증 후 jwt를 발급하는 필터 클래스이다.
- JwtAuthenticationFilter: 요청 헤더에 포함된 토큰을 읽어 토큰의 유효성 및 회원 정보를 확인하는 필터 클래스이다.
- RoleHierarchy 빈을 등록함으로써 Admin과 User 권한을 계층 형식으로 설정하였다.

JwtUtils 클래스에서 파라미터로 jwt를 전달받아 Authentication 객체를 리턴하는 getAuthentication() 함수를 구현하였는데, 이때 기존에 구현한 MemberDetails나 Member 엔티티 클래스를 사용하지 않고 스프링 시큐리티에서 지원하는 User 클래스를 사용하였다.
코드의 간소화를 위해 추후 회의 예정.

## 💭 주의 사항

## 💡 리뷰 포인트
