### PR TITLE
[FIX] 새 독후감 작성 시, 저장되지 않은 책인 경우의 로직 변경

### DIFF
--- a/src/main/java/com/example/turnpage/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/turnpage/domain/report/service/ReportServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.turnpage.domain.book.entity.Book;
 import com.example.turnpage.domain.book.service.BookService;
 import com.example.turnpage.domain.follow.service.FollowService;
 import com.example.turnpage.domain.member.entity.Member;
+import com.example.turnpage.domain.member.service.MemberService;
 import com.example.turnpage.domain.report.converter.ReportConverter;
 import com.example.turnpage.domain.report.dto.ReportRequest;
 import com.example.turnpage.domain.report.dto.ReportRequest.EditReportRequest;
@@ -39,10 +40,9 @@ public class ReportServiceImpl implements ReportService {
     @Transactional
     @Override
     public ReportId postReport(Member member, ReportRequest.PostReportRequest request) {
-        Long bookId = bookService.saveBook(request.getBookInfo())
-                .getBookId();
+        Book book = bookService.findBookByItemId(request.getBookInfo().getItemId())
+                .orElseGet(() -> bookService.saveBookInfo(request.getBookInfo()));
 
-        Book book = bookService.findBook(bookId);
         Report report = reportConverter.toEntity(request, book, member);
         Long reportId = reportRepository.save(report).getId();
 

--- a/src/main/java/com/example/turnpage/global/result/ResultResponse.java
+++ b/src/main/java/com/example/turnpage/global/result/ResultResponse.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 
 @Getter
 public class ResultResponse<T> {
-    private int status;
-    private String code;
-    private String message;
-    private T data;
+    private final int status;
+    private final String code;
+    private final String message;
+    private final T data;
     public ResultResponse(ResultCodeInterface resultCode, T data) {
         this.status = resultCode.getResultCode().getStatus();
         this.code = resultCode.getResultCode().getCode();


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #42

## 📝 작업 내용
새 독후감 작성 시, 대상 도서가 DB에 저장되어 있는지 판단 후, 저장되어 있지 않다면 bookService를 통해 대상 도서를 DB에 저장하는 로직을 추가하였다.

추가로, ResultResponse의 필드에 final을 추가하였다.
## 💭 주의 사항

## 💡 리뷰 포인트
