### PR TITLE
[FIX] 새 팔로우 시, 팔로우하는 회원이 자신인 경우 예외를 발생시키는 로직 추가

### DIFF
--- a/src/main/java/com/example/turnpage/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/example/turnpage/domain/follow/service/FollowServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.example.turnpage.global.error.domain.FollowErrorCode.CANNOT_FOLLOW_MYSELF;
 import static com.example.turnpage.global.error.domain.FollowErrorCode.FOLLOW_NOT_FOUND;
 
 @RequiredArgsConstructor
@@ -32,6 +33,8 @@ public class FollowServiceImpl implements FollowService {
     @Override
     public FollowId followMember(Member member, FollowRequest.FollowMemberRequest request) {
         Member follower = memberService.findMember(request.getEmail());
+        validateFollowerIsNotMyself(member, follower);
+
         Follow follow = followConverter.toEntity(member, follower);
 
         followRepository.save(follow);
@@ -56,5 +59,11 @@ public class FollowServiceImpl implements FollowService {
 
         follow.delete();
         return followConverter.toFollowId(follow.getId());
+    }
+
+    private void validateFollowerIsNotMyself(Member member, Member follower) {
+        if (member == follower) {
+            throw new BusinessException(CANNOT_FOLLOW_MYSELF);
+        }
     }
 }

--- a/src/main/java/com/example/turnpage/global/error/domain/FollowErrorCode.java
+++ b/src/main/java/com/example/turnpage/global/error/domain/FollowErrorCode.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FollowErrorCode implements ErrorCodeInterface {
     FOLLOW_NOT_FOUND(404, "EF001", "회원님은 해당 memberId를 가진 회원을 팔로우하고 있지 않습니다."),
-
+    CANNOT_FOLLOW_MYSELF(400, "EF002", "자기 자신을 팔로우할 수 없습니다."),
 
     ;
 


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #45

## 📝 작업 내용
팔로우하려는 회원이 자기 자신인지 검증하는 함수 `validateFollowerIsNotMyself(Member member, Member follower)` 함수를 구현하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트
