### PR TITLE
[FEAT] response DTO에 isSold, isMine 필드 추가, request DTO Validation 추가, 판매글 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/turnpage/domain/book/dto/BookRequest.java
+++ b/src/main/java/com/example/turnpage/domain/book/dto/BookRequest.java
@@ -1,5 +1,7 @@
 package com.example.turnpage.domain.book.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,10 +14,15 @@ public abstract class BookRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SaveBookRequest {
+        @NotNull
         private Long itemId;
+        @NotEmpty
         private String title;
+        @NotEmpty
         private String author;
+        @NotEmpty
         private String cover;
+        @NotEmpty
         private String isbn;
         private String publisher;
         private String publicationDate;

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -78,7 +78,7 @@ public class SalePostController {
 
     @Operation(summary = "판매 중인 도서 상세 조회 API", description = " 판매 중인 도서 상세 조회 API 입니다. path variable로 salePostId를 주세요.")
     @GetMapping("/{salePostId}")
-    public ResultResponse<SalePostDetailInfo> getSalePostDetailInfo(@PathVariable(value = "salePostId") Long salePostId) {
-        return ResultResponse.of(SALE_POST_DETAIL, salePostService.getSalePostDetailInfo(salePostId));
+    public ResultResponse<SalePostDetailInfo> getSalePostDetailInfo(@LoginMember Member member, @PathVariable(value = "salePostId") Long salePostId) {
+        return ResultResponse.of(SALE_POST_DETAIL, salePostService.getSalePostDetailInfo(member, salePostId));
     }
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -52,7 +52,8 @@ public class SalePostController {
         return ResultResponse.of(DELETE_SALE_POST, salePostService.deleteSalePost(member, salePostId));
     }
 
-    @Operation(summary = "판매 중인 도서 목록 조회 API", description = " 판매 중인 도서 목록 조회 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다.")
+    @Operation(summary = "판매글 목록 조회 API", description = " 판매 중인 도서 목록 조회 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
+            "total false 일 경우 판매 중인 도서만, true일 경우 판매완료된 도서도 함께 조회됩니다.")
     @Parameters(value = {
             @Parameter(name = "page", description = "page 시작은 0번부터입니다."),
             @Parameter(name = "size", description = "한 페이지에 보일 salePost 개수를 입력해주세요.")
@@ -64,7 +65,8 @@ public class SalePostController {
         return ResultResponse.of(SALE_POST_LIST, salePostService.fetchSalePosts(total, pageable));
     }
 
-    @Operation(summary = "판매 중인 도서 검색 API", description = " 판매 중인 도서 검색 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다.")
+    @Operation(summary = "판매글 검색 API", description = " 판매 중인 도서 검색 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
+            "total false 일 경우 판매 중인 도서만, true일 경우 판매완료된 도서도 함께 조회됩니다. keyword는 필수입니다.")
     @Parameters(value = {
             @Parameter(name = "page", description = "page 시작은 0번부터입니다."),
             @Parameter(name = "size", description = "한 페이지에 보일 salePost 개수를 입력해주세요.")
@@ -77,7 +79,7 @@ public class SalePostController {
         return ResultResponse.of(SEARCH_SALE_POST, salePostService.searchSalePost(total, keyword, pageable));
     }
 
-    @Operation(summary = "판매 중인 도서 상세 조회 API", description = " 판매 중인 도서 상세 조회 API 입니다. path variable로 salePostId를 주세요.")
+    @Operation(summary = "판매글 상세 조회 API", description = " 판매글 상세 조회 API 입니다. path variable로 salePostId를 주세요.")
     @GetMapping("/{salePostId}")
     public ResultResponse<SalePostDetailInfo> getSalePostDetailInfo(@LoginMember Member member, @PathVariable(value = "salePostId") Long salePostId) {
         return ResultResponse.of(SALE_POST_DETAIL, salePostService.getSalePostDetailInfo(member, salePostId));

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -31,11 +31,11 @@ public class SalePostController {
 
     private final SalePostService salePostService;
 
-    @Operation(summary = "판매글 저장 API", description = " 판매글 저장 API 입니다." )
+    @Operation(summary = "판매글 저장 API", description = " 판매글 저장 API 입니다.")
     @PostMapping
     public ResultResponse<SalePostId> saveSalePost(@LoginMember Member member,
                                                    @RequestBody @Valid SaveSalePostRequest request) {
-        return ResultResponse.of(SAVE_SALE_POST, salePostService.saveSalePost(member,request));
+        return ResultResponse.of(SAVE_SALE_POST, salePostService.saveSalePost(member, request));
     }
 
     @Operation(summary = "판매글 수정 API", description = " 판매글 수정 API 입니다. path variable로 수정하고자 하는 salePostId를 주세요.")
@@ -59,9 +59,10 @@ public class SalePostController {
             @Parameter(name = "size", description = "한 페이지에 보일 salePost 개수를 입력해주세요.")
     })
     @GetMapping
-    public ResultResponse<PagedSalePostInfo> fetchSalePosts(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-                                                                                 @Parameter(hidden = true) Pageable pageable) {
-        return ResultResponse.of(SALE_POST_LIST, salePostService.fetchSalePosts(pageable));
+    public ResultResponse<PagedSalePostInfo> fetchSalePosts(@RequestParam(name = "total") boolean total,
+                                                            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+                                                            @Parameter(hidden = true) Pageable pageable) {
+        return ResultResponse.of(SALE_POST_LIST, salePostService.fetchSalePosts(total, pageable));
     }
 
     @Operation(summary = "판매 중인 도서 검색 API", description = " 판매 중인 도서 검색 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다.")
@@ -70,10 +71,11 @@ public class SalePostController {
             @Parameter(name = "size", description = "한 페이지에 보일 salePost 개수를 입력해주세요.")
     })
     @GetMapping("/search")
-    public ResultResponse<PagedSalePostInfo> searchSalePost(@RequestParam(name = "keyword") String keyword,
+    public ResultResponse<PagedSalePostInfo> searchSalePost(@RequestParam(name = "total") boolean total,
+                                                            @RequestParam(name = "keyword") String keyword,
                                                             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
                                                             @Parameter(hidden = true) Pageable pageable) {
-        return ResultResponse.of(SEARCH_SALE_POST, salePostService.searchSalePost(keyword, pageable));
+        return ResultResponse.of(SEARCH_SALE_POST, salePostService.searchSalePost(total, keyword, pageable));
     }
 
     @Operation(summary = "판매 중인 도서 상세 조회 API", description = " 판매 중인 도서 상세 조회 API 입니다. path variable로 salePostId를 주세요.")

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -58,7 +58,7 @@ public class SalePostController {
             @Parameter(name = "size", description = "한 페이지에 보일 salePost 개수를 입력해주세요.")
     })
     @GetMapping
-    public ResultResponse<PagedSalePostInfo> fetchSalePosts(@RequestParam(name = "total") boolean total,
+    public ResultResponse<PagedSalePostInfo> fetchSalePosts(@RequestParam(name = "total", defaultValue = "false") boolean total,
                                                             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
                                                             @Parameter(hidden = true) Pageable pageable) {
         return ResultResponse.of(SALE_POST_LIST, salePostService.fetchSalePosts(total, pageable));
@@ -70,7 +70,7 @@ public class SalePostController {
             @Parameter(name = "size", description = "한 페이지에 보일 salePost 개수를 입력해주세요.")
     })
     @GetMapping("/search")
-    public ResultResponse<PagedSalePostInfo> searchSalePost(@RequestParam(name = "total") boolean total,
+    public ResultResponse<PagedSalePostInfo> searchSalePost(@RequestParam(name = "total", defaultValue = "false") boolean total,
                                                             @RequestParam(name = "keyword") String keyword,
                                                             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
                                                             @Parameter(hidden = true) Pageable pageable) {

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -3,7 +3,6 @@ package com.example.turnpage.domain.salePost.controller;
 import com.example.turnpage.domain.member.entity.Member;
 import com.example.turnpage.domain.salePost.dto.SalePostRequest.EditSalePostRequest;
 import com.example.turnpage.domain.salePost.dto.SalePostRequest.SaveSalePostRequest;
-import com.example.turnpage.domain.salePost.dto.SalePostResponse;
 import com.example.turnpage.domain.salePost.dto.SalePostResponse.PagedSalePostInfo;
 import com.example.turnpage.domain.salePost.service.SalePostService;
 import com.example.turnpage.global.config.security.LoginMember;
@@ -19,7 +18,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
-import static com.example.turnpage.domain.salePost.dto.SalePostResponse.*;
+import static com.example.turnpage.domain.salePost.dto.SalePostResponse.SalePostDetailInfo;
 import static com.example.turnpage.domain.salePost.dto.SalePostResponse.SalePostId;
 import static com.example.turnpage.global.result.code.SalePostResultCode.*;
 

--- a/src/main/java/com/example/turnpage/domain/salePost/converter/SalePostConverter.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/converter/SalePostConverter.java
@@ -6,7 +6,6 @@ import com.example.turnpage.domain.book.entity.Book;
 import com.example.turnpage.domain.member.converter.MemberConverter;
 import com.example.turnpage.domain.member.dto.MemberResponse;
 import com.example.turnpage.domain.member.entity.Member;
-import com.example.turnpage.domain.salePost.dto.SalePostResponse;
 import com.example.turnpage.domain.salePost.dto.SalePostResponse.PagedSalePostInfo;
 import com.example.turnpage.domain.salePost.dto.SalePostResponse.SalePostDetailInfo;
 import com.example.turnpage.domain.salePost.dto.SalePostResponse.SalePostInfo;

--- a/src/main/java/com/example/turnpage/domain/salePost/converter/SalePostConverter.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/converter/SalePostConverter.java
@@ -41,11 +41,12 @@ public class SalePostConverter {
                 .salePostId(salePost.getId())
                 .price(salePost.getPrice())
                 .grade(salePost.getGrade().getToKorean())
+                .isSold(salePost.isSold())
                 .createdAt(salePost.getCreatedAt())
                 .build();
     }
 
-    public SalePostDetailInfo toSalePostDetailInfo(SalePost salePost) {
+    public SalePostDetailInfo toSalePostDetailInfo(SalePost salePost, boolean isMine) {
         MemberResponse.MemberInfo memberInfo = memberConverter.toMemberInfo(salePost.getMember());
         BookResponse.BookInfo bookInfo = bookConverter.toBookInfo(salePost.getBook());
         return SalePostDetailInfo.builder()
@@ -56,6 +57,8 @@ public class SalePostConverter {
                 .price(salePost.getPrice())
                 .grade(salePost.getGrade().getToKorean())
                 .description(salePost.getDescription())
+                .isSold(salePost.isSold())
+                .isMine(isMine)
                 .createdAt(salePost.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostRequest.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostRequest.java
@@ -2,10 +2,7 @@ package com.example.turnpage.domain.salePost.dto;
 
 import com.example.turnpage.domain.book.dto.BookRequest.SaveBookRequest;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,8 +15,10 @@ public abstract class SalePostRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SaveSalePostRequest {
+        @Size(max = 30)
         @NotEmpty
         private String title;
+        @Size(max = 1000)
         @NotEmpty
         private String description;
         @NotBlank
@@ -34,8 +33,10 @@ public abstract class SalePostRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class EditSalePostRequest {
+        @Size(max = 30)
         @NotEmpty
         private String title;
+        @Size(max = 1000)
         @NotEmpty
         private String description;
         @NotBlank

--- a/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostRequest.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostRequest.java
@@ -2,6 +2,10 @@ package com.example.turnpage.domain.salePost.dto;
 
 import com.example.turnpage.domain.book.dto.BookRequest.SaveBookRequest;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,11 +18,14 @@ public abstract class SalePostRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SaveSalePostRequest {
+        @NotEmpty
         private String title;
+        @NotEmpty
         private String description;
+        @NotBlank
         private String grade;
+        @Positive
         private Integer price;
-        @JsonProperty("bookInfo")
         private SaveBookRequest bookInfo;
     }
 
@@ -27,9 +34,13 @@ public abstract class SalePostRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class EditSalePostRequest {
+        @NotEmpty
         private String title;
+        @NotEmpty
         private String description;
+        @NotBlank
         private String grade;
+        @Positive
         private Integer price;
     }
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostResponse.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostResponse.java
@@ -1,9 +1,7 @@
 package com.example.turnpage.domain.salePost.dto;
 
-import com.example.turnpage.domain.book.dto.BookResponse;
 import com.example.turnpage.domain.book.dto.BookResponse.BookInfo;
 import com.example.turnpage.domain.book.dto.BookResponse.SimpleBookInfo;
-import com.example.turnpage.domain.member.dto.MemberResponse;
 import com.example.turnpage.domain.member.dto.MemberResponse.MemberInfo;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostResponse.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostResponse.java
@@ -33,6 +33,7 @@ public abstract class SalePostResponse {
         private String title;
         private Integer price;
         private String grade;
+        private boolean isSold;
         @JsonFormat(pattern = "yyyy-MM-dd")
         private LocalDateTime createdAt;
     }
@@ -49,6 +50,8 @@ public abstract class SalePostResponse {
         private Integer price;
         private String grade;
         private String description;
+        private boolean isSold;
+        private boolean isMine;
         @JsonFormat(pattern = "yyyy-MM-dd")
         private LocalDateTime createdAt;
     }

--- a/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
@@ -1,6 +1,5 @@
 package com.example.turnpage.domain.salePost.repository;
 
-import com.example.turnpage.domain.book.entity.Book;
 import com.example.turnpage.domain.salePost.entity.SalePost;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
@@ -10,14 +9,18 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface SalePostRepository extends JpaRepository<SalePost,Long> {
-    @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book")
-    Page<SalePost> findSalePostsWithBooksOrderByCreatedAt(Pageable pageable);
+public interface SalePostRepository extends JpaRepository<SalePost, Long> {
+    @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book " +
+            "WHERE (:total = true OR sp.isSold = false) " +
+            "ORDER BY sp.createdAt")
+    Page<SalePost> findSalePostsWithBooksOrderByCreatedAt(@Param("total") boolean total, Pageable pageable);
 
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book WHERE REPLACE(sp.title,' ','') LIKE %:keyword% " +
             "OR REPLACE(sp.book.title,' ','') LIKE %:keyword% " +
-            "OR REPLACE(sp.book.author,' ','') LIKE %:keyword% ")
-    Page<SalePost> findByBookOrTitleContaining(@Param("keyword") String keyword, Pageable pageable);
+            "OR REPLACE(sp.book.author,' ','') LIKE %:keyword% " +
+            "AND (:total = true OR sp.isSold = false)" +
+            "ORDER BY sp.createdAt")
+    Page<SalePost> findByBookOrTitleContaining(@Param("total") boolean total, @Param("keyword") String keyword, Pageable pageable);
 
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.member JOIN FETCH sp.book WHERE sp.id = :salePostId")
     Optional<SalePost> findSalePostWithMemberAndBook(@Param("salePostId") Long salePostId);

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
@@ -18,6 +18,6 @@ public interface SalePostService {
     SalePost findSalePost(Long salePostId);
     PagedSalePostInfo fetchSalePosts(Pageable pageable);
     PagedSalePostInfo searchSalePost(String keyword, Pageable pageable);
-    SalePostDetailInfo getSalePostDetailInfo(Long salePostId);
+    SalePostDetailInfo getSalePostDetailInfo(Member member, Long salePostId);
 
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
@@ -16,8 +16,8 @@ public interface SalePostService {
     SalePostId editSalePost(Member loginMember, Long salePostId, EditSalePostRequest request);
     SalePostId deleteSalePost(Member loginMember, Long salePostId);
     SalePost findSalePost(Long salePostId);
-    PagedSalePostInfo fetchSalePosts(Pageable pageable);
-    PagedSalePostInfo searchSalePost(String keyword, Pageable pageable);
+    PagedSalePostInfo fetchSalePosts(boolean total, Pageable pageable);
+    PagedSalePostInfo searchSalePost(boolean total, String keyword, Pageable pageable);
     SalePostDetailInfo getSalePostDetailInfo(Member member, Long salePostId);
 
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
@@ -18,6 +18,6 @@ public interface SalePostService {
     SalePost findSalePost(Long salePostId);
     PagedSalePostInfo fetchSalePosts(boolean total, Pageable pageable);
     PagedSalePostInfo searchSalePost(boolean total, String keyword, Pageable pageable);
-    SalePostDetailInfo getSalePostDetailInfo(Member member, Long salePostId);
+    SalePostDetailInfo getSalePostDetailInfo(Member loginMember, Long salePostId);
 
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
@@ -57,7 +57,7 @@ public class SalePostServiceImpl implements SalePostService {
 
         checkIsSold(salePost);
 
-        checkMember(member, salePost.getMember());
+        checkWriter(member, salePost.getMember());
 
         salePost.update(request.getTitle(), request.getDescription(),
                 Grade.toGrade(request.getGrade()), request.getPrice());
@@ -73,7 +73,7 @@ public class SalePostServiceImpl implements SalePostService {
 
         checkIsSold(salePost);
 
-        checkMember(member, salePost.getMember());
+        checkWriter(member, salePost.getMember());
 
         salePost.delete();
 
@@ -99,7 +99,7 @@ public class SalePostServiceImpl implements SalePostService {
         SalePost salePost = salePostRepository.findSalePostWithMemberAndBook(salePostId)
                 .orElseThrow(() -> new BusinessException(SalePostErrorCode.SALE_POST_NOT_FOUND));
 
-        boolean isMine = checkIsMine(loginMember, salePost.getMember().getId());
+        boolean isMine = checkIsMine(loginMember, salePost.getMember());
 
         return salePostConverter.toSalePostDetailInfo(salePost, isMine);
     }
@@ -111,7 +111,7 @@ public class SalePostServiceImpl implements SalePostService {
                 () -> new BusinessException(SalePostErrorCode.SALE_POST_NOT_FOUND));
     }
 
-    private void checkMember(Member loginMember, Member writer) {
+    private void checkWriter(Member loginMember, Member writer) {
         if (!loginMember.getId().equals(writer.getId()))
             throw new BusinessException(SalePostErrorCode.NO_AUTHORIZATION_SALE_POST);
     }
@@ -121,8 +121,8 @@ public class SalePostServiceImpl implements SalePostService {
             throw new BusinessException(SalePostErrorCode.SALE_POST_NOT_ALLOWED);
     }
 
-    private boolean checkIsMine(Member loginMember, Long writerId) {
-        if (loginMember != null && writerId.equals(loginMember.getId()))
+    private boolean checkIsMine(Member loginMember, Member writer) {
+        if (loginMember != null && writer.getId().equals(loginMember.getId()))
             return true;
         else return false;
     }

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
@@ -43,8 +43,8 @@ public class SalePostServiceImpl implements SalePostService {
 
         //판매글 저장
         SalePost salePost = salePostRepository.save(salePostConverter.toEntity(member, book,
-                                                        request.getTitle(), request.getDescription(),
-                                                        Grade.toGrade(request.getGrade()), request.getPrice()));
+                request.getTitle(), request.getDescription(),
+                Grade.toGrade(request.getGrade()), request.getPrice()));
 
         return new SalePostId(salePost.getId());
     }
@@ -57,7 +57,7 @@ public class SalePostServiceImpl implements SalePostService {
 
         checkIsSold(salePost);
 
-        checkMember(member,salePost.getMember());
+        checkMember(member, salePost.getMember());
 
         salePost.update(request.getTitle(), request.getDescription(),
                 Grade.toGrade(request.getGrade()), request.getPrice());
@@ -73,7 +73,7 @@ public class SalePostServiceImpl implements SalePostService {
 
         checkIsSold(salePost);
 
-        checkMember(member,salePost.getMember());
+        checkMember(member, salePost.getMember());
 
         salePost.delete();
 
@@ -81,17 +81,17 @@ public class SalePostServiceImpl implements SalePostService {
     }
 
     @Override
-    public PagedSalePostInfo fetchSalePosts(Pageable pageable) {
+    public PagedSalePostInfo fetchSalePosts(boolean total, Pageable pageable) {
         return salePostConverter.toPagedSalePostList(
-                salePostRepository.findSalePostsWithBooksOrderByCreatedAt(pageable));
+                salePostRepository.findSalePostsWithBooksOrderByCreatedAt(total, pageable));
     }
 
     @Override
-    public PagedSalePostInfo searchSalePost(String keyword, Pageable pageable) {
-        keyword = keyword.replace(" ","");
+    public PagedSalePostInfo searchSalePost(boolean total, String keyword, Pageable pageable) {
+        keyword = keyword.replace(" ", "");
 
         return salePostConverter.toPagedSalePostList(
-                salePostRepository.findByBookOrTitleContaining(keyword,pageable));
+                salePostRepository.findByBookOrTitleContaining(total, keyword, pageable));
     }
 
     @Override
@@ -112,19 +112,18 @@ public class SalePostServiceImpl implements SalePostService {
     }
 
     private void checkMember(Member loginMember, Member writer) {
-        if(!loginMember.getId().equals(writer.getId()))
+        if (!loginMember.getId().equals(writer.getId()))
             throw new BusinessException(SalePostErrorCode.NO_AUTHORIZATION_SALE_POST);
     }
 
     private void checkIsSold(SalePost salePost) {
-        if(salePost.isSold())
+        if (salePost.isSold())
             throw new BusinessException(SalePostErrorCode.SALE_POST_NOT_ALLOWED);
     }
 
     private boolean checkIsMine(Member loginMember, Long writerId) {
-        if(loginMember!=null && writerId.equals(loginMember.getId()))
+        if (loginMember != null && writerId.equals(loginMember.getId()))
             return true;
         else return false;
     }
-
 }

--- a/src/main/java/com/example/turnpage/global/error/code/SalePostErrorCode.java
+++ b/src/main/java/com/example/turnpage/global/error/code/SalePostErrorCode.java
@@ -10,7 +10,7 @@ public enum SalePostErrorCode implements ErrorCode {
     SALE_POST_NOT_FOUND(400, "ES001", "해당 salePostId를 가진 판매글이 존재하지 않습니다."),
     INVALID_GRADE_INPUT(400,"ES002", "GRADE enum값이 올바르지 않습니다. 최상, 상, 중, 하 중에 선택해주세요."),
     NO_AUTHORIZATION_SALE_POST(400, "ES003", "해당 판매글에 대한 수정,삭제 권한이 없습니다."),
-
+    SALE_POST_NOT_ALLOWED(400, "ES004", "판매 완료된 게시글은 수정,삭제할 수 없습니다."),
     ;
     private final int status;
     private final String code;

--- a/src/test/java/com/example/turnpage/domain/salePost/controller/SalePostControllerTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/controller/SalePostControllerTest.java
@@ -235,7 +235,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        given(salePostService.getSalePostDetailInfo(any())).willReturn(response);
+        given(salePostService.getSalePostDetailInfo(any(),any())).willReturn(response);
 
         //when
         ResultActions resultActions = mockMvc.perform(
@@ -251,7 +251,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.data.bookInfo.bookId").value(1))
         ;
 
-        verify(salePostService).getSalePostDetailInfo(any());
+        verify(salePostService).getSalePostDetailInfo(any(),any());
     }
 
 }

--- a/src/test/java/com/example/turnpage/domain/salePost/controller/SalePostControllerTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/controller/SalePostControllerTest.java
@@ -164,7 +164,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .isLast(false)
                 .build();
 
-        given(salePostService.fetchSalePosts(any())).willReturn(response);
+        given(salePostService.fetchSalePosts(any(),any())).willReturn(response);
 
         //when
         ResultActions resultActions = mockMvc.perform(
@@ -179,7 +179,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.data.totalElements").value(1))
         ;
 
-        verify(salePostService).fetchSalePosts(any());
+        verify(salePostService).fetchSalePosts(any(),any());
     }
 
     @Test
@@ -196,7 +196,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .isLast(false)
                 .build();
 
-        given(salePostService.searchSalePost(any(),any())).willReturn(response);
+        given(salePostService.searchSalePost(any(),any(),any())).willReturn(response);
 
         //when
         ResultActions resultActions = mockMvc.perform(
@@ -213,7 +213,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.data.totalElements").value(1))
         ;
 
-        verify(salePostService).searchSalePost(any(), any());
+        verify(salePostService).searchSalePost(any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/example/turnpage/domain/salePost/controller/SalePostControllerTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/controller/SalePostControllerTest.java
@@ -6,7 +6,6 @@ import com.example.turnpage.domain.member.dto.MemberResponse;
 import com.example.turnpage.domain.member.entity.Member;
 import com.example.turnpage.domain.salePost.dto.SalePostRequest.EditSalePostRequest;
 import com.example.turnpage.domain.salePost.dto.SalePostRequest.SaveSalePostRequest;
-import com.example.turnpage.domain.salePost.dto.SalePostResponse;
 import com.example.turnpage.domain.salePost.dto.SalePostResponse.PagedSalePostInfo;
 import com.example.turnpage.domain.salePost.dto.SalePostResponse.SalePostDetailInfo;
 import com.example.turnpage.domain.salePost.dto.SalePostResponse.SalePostId;

--- a/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
@@ -197,11 +197,54 @@ public class SalePostServiceTest extends ServiceTestConfig {
             salePostService.saveSalePost(testMember, request);
         }
         //when
+        testSalePost.setSold();
         Pageable pageable = PageRequest.of(0, 20);
-        PagedSalePostInfo salePostList = salePostService.fetchSalePosts(pageable);
+        PagedSalePostInfo salePostList = salePostService.fetchSalePosts(true, pageable);
+
 
         //then
         assertEquals(11, salePostList.getTotalElements());
+        assertEquals(0, salePostList.getPage());
+        assertEquals(1, salePostList.getTotalPages());
+        assertEquals("제목",salePostList.getSalePostInfoList().get(0).getTitle());
+        assertEquals("꿈꾸지 않아도 빤짝이는 중 - 놀면서 일하는 두 남자 삐까뚱씨, 내일의 목표보단 오늘의 행복에 집중하는 인생로그",
+                salePostList.getSalePostInfoList().get(0).getBookInfo().getTitle());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("판매글 목록 조회 성공 테스트 - 판매중인 게시글만 보기")
+    public void fetchSalePost2() {
+        //given
+        for(int i=1;i<=10;i++) {
+            SaveBookRequest bookRequest = SaveBookRequest.builder()
+                    .itemId((long) i)
+                    .title("꿈꾸지 않아도 빤짝이는 중 - 놀면서 일하는 두 남자 삐까뚱씨, 내일의 목표보단 오늘의 행복에 집중하는 인생로그")
+                    .author("브로디, 노아")
+                    .cover("https://image.aladin.co.kr/product/33948/74/coversum/k392930236_1.jpg")
+                    .isbn("12987349382")
+                    .publisher("포레스트북스")
+                    .publicationDate("2023-12-18")
+                    .description("삐까뚱씨라는 이름으로 유튜브를 하고 있는 브로디와 노아.")
+                    .build();
+
+            SaveSalePostRequest request = SaveSalePostRequest.builder()
+                    .title("제목")
+                    .description("설명")
+                    .grade("최상")
+                    .price(10000)
+                    .bookInfo(bookRequest)
+                    .build();
+
+            salePostService.saveSalePost(testMember, request);
+        }
+        //when
+        testSalePost.setSold();
+        Pageable pageable = PageRequest.of(0, 20);
+        PagedSalePostInfo salePostList = salePostService.fetchSalePosts(false, pageable);
+
+        //then
+        assertEquals(10, salePostList.getTotalElements());
         assertEquals(0, salePostList.getPage());
         assertEquals(1, salePostList.getTotalPages());
         assertEquals("제목",salePostList.getSalePostInfoList().get(0).getTitle());
@@ -216,7 +259,7 @@ public class SalePostServiceTest extends ServiceTestConfig {
 
         //given & when
         Pageable pageable = PageRequest.of(0, 20);
-        PagedSalePostInfo salePostList = salePostService.searchSalePost("제목",pageable);
+        PagedSalePostInfo salePostList = salePostService.searchSalePost(false,"제목",pageable);
 
         assertEquals(0, salePostList.getPage());
         assertEquals(1,salePostList.getTotalPages());

--- a/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
@@ -94,6 +94,27 @@ public class SalePostServiceTest extends ServiceTestConfig {
         assertEquals(SalePostErrorCode.INVALID_GRADE_INPUT, exception.getErrorCode());
     }
 
+
+    @Test
+    @Transactional
+    @DisplayName("판매글 수정 실패 테스트 - 판매 작성자가 로그인 멤버가 아님")
+    public void editSalePostFail() {
+        //given
+        EditSalePostRequest request = EditSalePostRequest.builder()
+                .title("수정제목")
+                .description("수정설명")
+                .grade("상")
+                .price(20000)
+                .build();
+
+        //when
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            salePostService.editSalePost(testMember2, testSalePost.getId(), request);
+        });
+
+        //then
+        assertEquals(SalePostErrorCode.NO_AUTHORIZATION_SALE_POST, exception.getErrorCode());
+    }
     @Test
     @Transactional
     @DisplayName("판매글 수정 성공 테스트")
@@ -119,6 +140,23 @@ public class SalePostServiceTest extends ServiceTestConfig {
         assertNotNull(salePost.getUpdatedAt());
     }
 
+
+    @Test
+    @Transactional
+    @DisplayName("판매글 삭제 실패 테스트 - 판매 완료된 게시글을 삭제할 수 없음")
+    public void deleteSalePostFail() {
+
+        //given
+        testSalePost.setSold();
+
+        //when
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            salePostService.deleteSalePost(testMember, testSalePost.getId());
+        });
+
+        //then
+        assertEquals(SalePostErrorCode.SALE_POST_NOT_ALLOWED, exception.getErrorCode());
+    }
 
 
     @Test
@@ -190,11 +228,11 @@ public class SalePostServiceTest extends ServiceTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("판매글 상세 조회 성공 테스트")
+    @DisplayName("판매글 상세 조회 성공 테스트 - 로그인 했을 경우")
     public void getSalePostDetail() {
 
         //given & when
-        SalePostDetailInfo detailInfo = salePostService.getSalePostDetailInfo(testSalePost.getId());
+        SalePostDetailInfo detailInfo = salePostService.getSalePostDetailInfo(testMember,testSalePost.getId());
 
         //then
         assertEquals("제목", detailInfo.getTitle());
@@ -204,6 +242,19 @@ public class SalePostServiceTest extends ServiceTestConfig {
         assertEquals("꿈꾸지 않아도 빤짝이는 중 - 놀면서 일하는 두 남자 삐까뚱씨, 내일의 목표보단 오늘의 행복에 집중하는 인생로그",
                 detailInfo.getBookInfo().getTitle());
         assertEquals("수밈", detailInfo.getMemberInfo().getName());
+        assertEquals(true, detailInfo.isMine());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("판매글 상세 조회 성공 테스트2 - 로그인 하지 않았을 경우")
+    public void getSalePostDetail2() {
+
+        //given & when
+        SalePostDetailInfo detailInfo = salePostService.getSalePostDetailInfo(null,testSalePost.getId());
+
+        //then
+        assertEquals(false, detailInfo.isMine());
     }
 
 

--- a/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
@@ -271,8 +271,24 @@ public class SalePostServiceTest extends ServiceTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("판매글 상세 조회 성공 테스트 - 로그인 했을 경우")
+    @DisplayName("판매글 상세 조회 실패 테스트 - salePostId를 찾을 수 없음")
     public void getSalePostDetail() {
+
+        //when
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            salePostService.getSalePostDetailInfo(testMember,1001L);
+        });
+
+        //then
+        assertEquals(SalePostErrorCode.SALE_POST_NOT_FOUND, exception.getErrorCode());
+
+    }
+
+
+    @Test
+    @Transactional
+    @DisplayName("판매글 상세 조회 성공 테스트 - 로그인 했을 경우")
+    public void getSalePostDetailFail() {
 
         //given & when
         SalePostDetailInfo detailInfo = salePostService.getSalePostDetailInfo(testMember,testSalePost.getId());


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #57 

## 📝 작업 내용
1. responseDTO에 isSold, isMine 필드를 추가하여 판매 완료된 글인지, 로그인한 멤버의 글인지 확인할수 있도록 하였습니다. 
로그인하지 않은 상태라면 isMine은 false로 넘어갑니다.
2. requestDTO에 Validation을 추가하였습니다.
3. 판매글 목록 조회, 검색 로직을 수정하였습니다. boolean type의 total을 파라미터로받아서 false이면 판매중인 글만, true이면 판매중+판매완료 모두 조회할 수 있도록 하였습니다. 기본 false입니다.
## 💭 주의 사항

## 💡 리뷰 포인트
* 서비스 테스트 결과

<img width="473" alt="스크린샷 2024-06-19 오후 4 41 17" src="https://github.com/Turn-Page/Server/assets/83461362/da4694a9-d54e-4fd0-a43a-15eb42bf98ec">
