### PR TITLE
[FEAT] 내 판매 내역 조회API, 판매글 등록 삭제 시 count 조정

### DIFF
--- a/src/main/java/com/example/turnpage/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/turnpage/domain/book/controller/BookController.java
@@ -31,7 +31,7 @@ public class BookController {
     private final BookSearchClient bookSearchClient;
 
     @PostMapping()
-    @Operation(summary = "책 정보 저장 API", description = " 책 정보 저장 API 입니다.")
+    @Operation(summary = "책 정보 저장 API", description = "책 정보 저장 API 입니다.")
     public ResultResponse<BookId> saveBook(SaveBookRequest request) {
 
         return ResultResponse.of(SAVE_BOOK,  bookService.saveBook(request));
@@ -42,7 +42,7 @@ public class BookController {
             @Parameter(name = "page", description = "page 시작은 0번부터입니다."),
             @Parameter(name = "size", description = "한 페이지에 보일 book 개수를 입력해주세요.")
     })
-    @Operation(summary = "베스트 셀러 목록 조회 API", description = " 베스트 셀러 목록 조회 API 입니다.")
+    @Operation(summary = "베스트 셀러 목록 조회 API", description = "베스트 셀러 목록 조회 API 입니다.")
     public ResultResponse<PagedBookInfo> fetchBestSeller(@PageableDefault(sort = "ranking", direction = Sort.Direction.ASC)
                                                               @Parameter(hidden = true) Pageable pageable) {
         return ResultResponse.of(FETCH_BESTSELLER, bookService.fetchBestSeller(pageable));
@@ -52,7 +52,7 @@ public class BookController {
     @Parameters(value = {
             @Parameter(name = "bookId", description = "path variable로 bookId를 주세요."),
     })
-    @Operation(summary = "책 정보 상세 조회 API", description = " 책 정보 상세 조회 API 입니다.")
+    @Operation(summary = "책 정보 상세 조회 API", description = "책 정보 상세 조회 API 입니다.")
     public ResultResponse<BookDetailInfo> getBookDetailInfo(@PathVariable("bookId") Long bookId) {
         return ResultResponse.of(BOOK_INFO, bookService.getBookDetailInfo(bookId));
     }
@@ -63,14 +63,14 @@ public class BookController {
             @Parameter(name = "page", description = "page 시작은 0번부터입니다."),
             @Parameter(name = "size", description = "한 페이지에 보일 book 개수를 입력해주세요.")
     })
-    @Operation(summary = "책 검색 API", description = " 책 검색 API 입니다. 책 이름이나 작가로 책을 검색할 수 있습니다.")
+    @Operation(summary = "책 검색 API", description = "책 검색 API 입니다. 책 이름이나 작가로 책을 검색할 수 있습니다.")
     public ResultResponse<PagedBookInfo> searchBook(@RequestParam(name = "keyword") String keyword,
                                                     @PageableDefault @Parameter(hidden = true) Pageable pageable) {
         return ResultResponse.of(SEARCH_BOOK, bookService.searchBook(keyword, pageable));
     }
 
     @GetMapping("/openAPI/search")
-    @Operation(summary = "알라딘 OPEN API에서 책 검색 API", description = " 알라딘 OPEN API 에서 검색 API 입니다. 책 이름이나 작가로 책을 검색할 수 있습니다." +
+    @Operation(summary = "알라딘 OPEN API에서 책 검색 API", description = "알라딘 OPEN API 에서 검색 API 입니다. 책 이름이나 작가로 책을 검색할 수 있습니다." +
             "검색 결과 10개까지 반환됩니다.")
     public ResultResponse<List<SaveBookRequest>> openAPISearchBook(@RequestParam(name = "keyword") String keyword) {
         return ResultResponse.of(SEARCH_BOOK, bookSearchClient.getSearchResult(keyword));

--- a/src/main/java/com/example/turnpage/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/turnpage/domain/member/controller/MemberController.java
@@ -24,13 +24,13 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "마이페이지 프로필 조회 API", description = " 프로필 조회 API 입니다." )
+    @Operation(summary = "마이페이지 프로필 조회 API", description = "프로필 조회 API 입니다." )
     @GetMapping("/myPage")
     public ResultResponse<MyPageInfo> getMyPageInfo(@LoginMember Member member) {
         return ResultResponse.of(MYPAGE_INFO, memberService.getMyPageInfo(member));
     }
 
-    @Operation(summary = "마이페이지 프로필 수정 API", description = " 프로필 수정 API 입니다." +
+    @Operation(summary = "마이페이지 프로필 수정 API", description = "프로필 수정 API 입니다." +
             "사용자 닉네임과, 프로필 사진을 변경할 수 있습니다.")
     @PatchMapping(value = "/myPage")
     public ResultResponse<MemberId> editMyPageInfo(@LoginMember Member member,
@@ -39,7 +39,7 @@ public class MemberController {
         return ResultResponse.of(EDIT_MYPAGE_INFO, memberService.editMyPageInfo(member, request, profileImage));
     }
 
-    @Operation(summary = "포인트 충전 API", description = " 포인트 충전 API 입니다." +
+    @Operation(summary = "포인트 충전 API", description = "포인트 충전 API 입니다." +
             "파라미터로 충전할 포인트를 주세요.")
     @PatchMapping(value = "/myPoint")
     public ResultResponse<MyPoint> chargeMyPoint(@LoginMember Member member,

--- a/src/main/java/com/example/turnpage/domain/member/entity/Member.java
+++ b/src/main/java/com/example/turnpage/domain/member/entity/Member.java
@@ -90,4 +90,19 @@ public class Member extends BaseTimeEntity {
         this.point -= point;
         return this.point;
     }
+
+    public void incrementSaleCount() {
+        this.saleCount += 1;
+    }
+    public void incrementPurchaseCount() {
+        this.purchaseCount += 1;
+    }
+
+    public void incrementReportCount() {
+        this.reportCount += 1;
+    }
+
+    public void decrementReportCount() {
+        this.reportCount -= 1;
+    }
 }

--- a/src/main/java/com/example/turnpage/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/example/turnpage/domain/order/service/OrderServiceImpl.java
@@ -70,6 +70,9 @@ public class OrderServiceImpl implements OrderService {
         persistedMember.subtractPoint(paymentAmount);
         seller.addPoint(paymentAmount);
 
+        persistedMember.incrementPurchaseCount();
+        seller.incrementSaleCount();
+
         return orderConverter.toSimpleOrderInfo(order);
     }
 

--- a/src/main/java/com/example/turnpage/domain/report/controller/ReportController.java
+++ b/src/main/java/com/example/turnpage/domain/report/controller/ReportController.java
@@ -3,9 +3,9 @@ package com.example.turnpage.domain.report.controller;
 import com.example.turnpage.domain.member.entity.Member;
 import com.example.turnpage.domain.report.dto.ReportRequest;
 import com.example.turnpage.domain.report.dto.ReportRequest.PostReportRequest;
+import com.example.turnpage.domain.report.dto.ReportResponse.DetailedReportInfo;
 import com.example.turnpage.domain.report.dto.ReportResponse.PagedReportInfo;
 import com.example.turnpage.domain.report.dto.ReportResponse.ReportId;
-import com.example.turnpage.domain.report.dto.ReportResponse.ReportInfo;
 import com.example.turnpage.domain.report.service.ReportService;
 import com.example.turnpage.global.config.security.LoginMember;
 import com.example.turnpage.global.result.ResultResponse;
@@ -18,14 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.example.turnpage.global.result.code.ReportResultcode.*;
 
@@ -75,8 +68,8 @@ public class ReportController {
             @Parameter(name = "reportId", description = "조회하고자 하는 독후감의 reportId를 입력해 주세요.")
     })
     @Operation(summary = "특정 독후감 조회 API", description = "reportId를 통한 특정 독후감 조회 API입니다.")
-    ResultResponse<ReportInfo> getReport(@LoginMember Member member,
-                                         @PathVariable("reportId") Long reportId) {
+    ResultResponse<DetailedReportInfo> getReport(@LoginMember Member member,
+                                                 @PathVariable("reportId") Long reportId) {
         return ResultResponse.of(GET_SPECIFIC_REPORT, reportService.getReport(member, reportId));
     }
 

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -30,14 +30,14 @@ public class SalePostController {
 
     private final SalePostService salePostService;
 
-    @Operation(summary = "판매글 저장 API", description = " 판매글 저장 API 입니다.")
+    @Operation(summary = "판매글 저장 API", description = "판매글 저장 API 입니다.")
     @PostMapping
     public ResultResponse<SalePostId> saveSalePost(@LoginMember Member member,
                                                    @RequestBody @Valid SaveSalePostRequest request) {
         return ResultResponse.of(SAVE_SALE_POST, salePostService.saveSalePost(member, request));
     }
 
-    @Operation(summary = "판매글 수정 API", description = " 판매글 수정 API 입니다. path variable로 수정하고자 하는 salePostId를 주세요.")
+    @Operation(summary = "판매글 수정 API", description = "판매글 수정 API 입니다. path variable로 수정하고자 하는 salePostId를 주세요.")
     @PatchMapping(value = "/{salePostId}")
     public ResultResponse<SalePostId> editSalePost(@LoginMember Member member,
                                                    @PathVariable(value = "salePostId") Long salePostId,
@@ -45,14 +45,14 @@ public class SalePostController {
         return ResultResponse.of(EDIT_SALE_POST, salePostService.editSalePost(member, salePostId, request));
     }
 
-    @Operation(summary = "판매글 삭제 API", description = " 판매글 삭제 API 입니다. path variable로 삭제하고자 하는 salePostId를 주세요.")
+    @Operation(summary = "판매글 삭제 API", description = "판매글 삭제 API 입니다. path variable로 삭제하고자 하는 salePostId를 주세요.")
     @DeleteMapping(value = "/{salePostId}")
     public ResultResponse<SalePostId> deleteSalePost(@LoginMember Member member,
                                                      @PathVariable(value = "salePostId") Long salePostId) {
         return ResultResponse.of(DELETE_SALE_POST, salePostService.deleteSalePost(member, salePostId));
     }
 
-    @Operation(summary = "판매글 목록 조회 API", description = " 판매 중인 도서 목록 조회 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
+    @Operation(summary = "판매글 목록 조회 API", description = "판매 중인 도서 목록 조회 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
             "total false 일 경우 판매 중인 도서만, true일 경우 판매완료된 도서도 함께 조회됩니다.")
     @Parameters(value = {
             @Parameter(name = "page", description = "page 시작은 0번부터입니다."),
@@ -65,7 +65,7 @@ public class SalePostController {
         return ResultResponse.of(SALE_POST_LIST, salePostService.fetchSalePosts(total, pageable));
     }
 
-    @Operation(summary = "판매글 검색 API", description = " 판매 중인 도서 검색 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
+    @Operation(summary = "판매글 검색 API", description = "판매 중인 도서 검색 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
             "total false 일 경우 판매 중인 도서만, true일 경우 판매완료된 도서도 함께 조회됩니다. keyword는 필수입니다.")
     @Parameters(value = {
             @Parameter(name = "page", description = "page 시작은 0번부터입니다."),
@@ -79,13 +79,13 @@ public class SalePostController {
         return ResultResponse.of(SEARCH_SALE_POST, salePostService.searchSalePost(total, keyword, pageable));
     }
 
-    @Operation(summary = "판매글 상세 조회 API", description = " 판매글 상세 조회 API 입니다. path variable로 salePostId를 주세요.")
+    @Operation(summary = "판매글 상세 조회 API", description = "판매글 상세 조회 API 입니다. path variable로 salePostId를 주세요.")
     @GetMapping("/{salePostId}")
     public ResultResponse<SalePostDetailInfo> getSalePostDetailInfo(@LoginMember Member member, @PathVariable(value = "salePostId") Long salePostId) {
         return ResultResponse.of(SALE_POST_DETAIL, salePostService.getSalePostDetailInfo(member, salePostId));
     }
 
-    @Operation(summary = "내 판매글 목록 조회 API", description = " 로그인 멤버가 작성한 판매글목록 조회 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
+    @Operation(summary = "내 판매글 목록 조회 API", description = "로그인 멤버가 작성한 판매글목록 조회 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
             "total false 일 경우 판매 중인 도서만, true일 경우 판매완료된 도서도 함께 조회됩니다.")
     @Parameters(value = {
             @Parameter(name = "page", description = "page 시작은 0번부터입니다."),

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -84,4 +84,18 @@ public class SalePostController {
     public ResultResponse<SalePostDetailInfo> getSalePostDetailInfo(@LoginMember Member member, @PathVariable(value = "salePostId") Long salePostId) {
         return ResultResponse.of(SALE_POST_DETAIL, salePostService.getSalePostDetailInfo(member, salePostId));
     }
+
+    @Operation(summary = "내 판매글 목록 조회 API", description = " 로그인 멤버가 작성한 판매글목록 조회 API 입니다. page는 0부터 시작합니다. 생성일 내림차순으로 조회됩니다." +
+            "total false 일 경우 판매 중인 도서만, true일 경우 판매완료된 도서도 함께 조회됩니다.")
+    @Parameters(value = {
+            @Parameter(name = "page", description = "page 시작은 0번부터입니다."),
+            @Parameter(name = "size", description = "한 페이지에 보일 salePost 개수를 입력해주세요.")
+    })
+    @GetMapping("/my")
+    public ResultResponse<PagedSalePostInfo> fetchMySalePosts(@LoginMember Member member, @RequestParam
+                                                              @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+                                                              @Parameter(hidden = true) Pageable pageable) {
+        return ResultResponse.of(SALE_POST_LIST, salePostService.fetchMySalePosts(member, pageable));
+    }
+
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
@@ -60,8 +59,7 @@ public class SalePostController {
     })
     @GetMapping
     public ResultResponse<PagedSalePostInfo> fetchSalePosts(@RequestParam(name = "total", defaultValue = "false") boolean total,
-                                                            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-                                                            @Parameter(hidden = true) Pageable pageable) {
+                                                            @PageableDefault @Parameter(hidden = true) Pageable pageable) {
         return ResultResponse.of(SALE_POST_LIST, salePostService.fetchSalePosts(total, pageable));
     }
 
@@ -74,8 +72,7 @@ public class SalePostController {
     @GetMapping("/search")
     public ResultResponse<PagedSalePostInfo> searchSalePost(@RequestParam(name = "total", defaultValue = "false") boolean total,
                                                             @RequestParam(name = "keyword") String keyword,
-                                                            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-                                                            @Parameter(hidden = true) Pageable pageable) {
+                                                            @PageableDefault @Parameter(hidden = true) Pageable pageable) {
         return ResultResponse.of(SEARCH_SALE_POST, salePostService.searchSalePost(total, keyword, pageable));
     }
 
@@ -94,8 +91,7 @@ public class SalePostController {
     @GetMapping("/my")
     public ResultResponse<PagedSalePostInfo> fetchMySalePosts(@LoginMember Member member,
                                                               @RequestParam(name = "total", defaultValue = "false") boolean total,
-                                                              @RequestParam
-                                                              @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+                                                              @RequestParam @PageableDefault
                                                               @Parameter(hidden = true) Pageable pageable) {
         return ResultResponse.of(SALE_POST_LIST, salePostService.fetchMySalePosts(member, total, pageable));
     }

--- a/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/controller/SalePostController.java
@@ -92,10 +92,12 @@ public class SalePostController {
             @Parameter(name = "size", description = "한 페이지에 보일 salePost 개수를 입력해주세요.")
     })
     @GetMapping("/my")
-    public ResultResponse<PagedSalePostInfo> fetchMySalePosts(@LoginMember Member member, @RequestParam
+    public ResultResponse<PagedSalePostInfo> fetchMySalePosts(@LoginMember Member member,
+                                                              @RequestParam(name = "total", defaultValue = "false") boolean total,
+                                                              @RequestParam
                                                               @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
                                                               @Parameter(hidden = true) Pageable pageable) {
-        return ResultResponse.of(SALE_POST_LIST, salePostService.fetchMySalePosts(member, pageable));
+        return ResultResponse.of(SALE_POST_LIST, salePostService.fetchMySalePosts(member, total, pageable));
     }
 
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
@@ -25,6 +25,7 @@ public interface SalePostRepository extends JpaRepository<SalePost, Long> {
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.member JOIN FETCH sp.book WHERE sp.id = :salePostId")
     Optional<SalePost> findSalePostWithMemberAndBook(@Param("salePostId") Long salePostId);
 
-    @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book WHERE sp.member.id = :memberId ORDER BY sp.createdAt DESC")
-    Page<SalePost> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+    @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book WHERE sp.member.id = :memberId" +
+            " AND (:total = true OR sp.isSold = false) ORDER BY sp.createdAt DESC")
+    Page<SalePost> findByMemberId(@Param("memberId") Long memberId, @Param("total") boolean total, Pageable pageable);
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
@@ -6,9 +6,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface SalePostRepository extends JpaRepository<SalePost, Long> {
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book " +
             "WHERE (:total = true OR sp.isSold = false) " +

--- a/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
@@ -12,16 +12,19 @@ import java.util.Optional;
 public interface SalePostRepository extends JpaRepository<SalePost, Long> {
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book " +
             "WHERE (:total = true OR sp.isSold = false) " +
-            "ORDER BY sp.createdAt")
+            "ORDER BY sp.createdAt DESC ")
     Page<SalePost> findSalePostsWithBooksOrderByCreatedAt(@Param("total") boolean total, Pageable pageable);
 
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book WHERE REPLACE(sp.title,' ','') LIKE %:keyword% " +
             "OR REPLACE(sp.book.title,' ','') LIKE %:keyword% " +
             "OR REPLACE(sp.book.author,' ','') LIKE %:keyword% " +
             "AND (:total = true OR sp.isSold = false)" +
-            "ORDER BY sp.createdAt")
+            "ORDER BY sp.createdAt DESC")
     Page<SalePost> findByBookOrTitleContaining(@Param("total") boolean total, @Param("keyword") String keyword, Pageable pageable);
 
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.member JOIN FETCH sp.book WHERE sp.id = :salePostId")
     Optional<SalePost> findSalePostWithMemberAndBook(@Param("salePostId") Long salePostId);
+
+    @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book WHERE sp.member.id = :memberId ORDER BY sp.createdAt DESC")
+    Page<SalePost> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/repository/SalePostRepository.java
@@ -15,7 +15,7 @@ public interface SalePostRepository extends JpaRepository<SalePost, Long> {
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book " +
             "WHERE (:total = true OR sp.isSold = false) " +
             "ORDER BY sp.createdAt DESC ")
-    Page<SalePost> findSalePostsWithBooksOrderByCreatedAt(@Param("total") boolean total, Pageable pageable);
+    Page<SalePost> findSalePostsWithBooksOrderByCreatedAtDesc(@Param("total") boolean total, Pageable pageable);
 
     @Query("SELECT sp FROM SalePost sp JOIN FETCH sp.book WHERE REPLACE(sp.title,' ','') LIKE %:keyword% " +
             "OR REPLACE(sp.book.title,' ','') LIKE %:keyword% " +

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
@@ -19,5 +19,7 @@ public interface SalePostService {
     PagedSalePostInfo fetchSalePosts(boolean total, Pageable pageable);
     PagedSalePostInfo searchSalePost(boolean total, String keyword, Pageable pageable);
     SalePostDetailInfo getSalePostDetailInfo(Member loginMember, Long salePostId);
+    PagedSalePostInfo fetchMySalePosts(Member loginMember, Pageable pageable);
+
 
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
@@ -19,7 +19,7 @@ public interface SalePostService {
     PagedSalePostInfo fetchSalePosts(boolean total, Pageable pageable);
     PagedSalePostInfo searchSalePost(boolean total, String keyword, Pageable pageable);
     SalePostDetailInfo getSalePostDetailInfo(Member loginMember, Long salePostId);
-    PagedSalePostInfo fetchMySalePosts(Member loginMember,boolean total,Pageable pageable);
+    PagedSalePostInfo fetchMySalePosts(Member loginMember, boolean total, Pageable pageable);
 
 
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostService.java
@@ -19,7 +19,7 @@ public interface SalePostService {
     PagedSalePostInfo fetchSalePosts(boolean total, Pageable pageable);
     PagedSalePostInfo searchSalePost(boolean total, String keyword, Pageable pageable);
     SalePostDetailInfo getSalePostDetailInfo(Member loginMember, Long salePostId);
-    PagedSalePostInfo fetchMySalePosts(Member loginMember, Pageable pageable);
+    PagedSalePostInfo fetchMySalePosts(Member loginMember,boolean total,Pageable pageable);
 
 
 }

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
@@ -83,7 +83,7 @@ public class SalePostServiceImpl implements SalePostService {
     @Override
     public PagedSalePostInfo fetchSalePosts(boolean total, Pageable pageable) {
         return salePostConverter.toPagedSalePostList(
-                salePostRepository.findSalePostsWithBooksOrderByCreatedAt(total, pageable));
+                salePostRepository.findSalePostsWithBooksOrderByCreatedAtDesc(total, pageable));
     }
 
     @Override

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
@@ -104,6 +104,14 @@ public class SalePostServiceImpl implements SalePostService {
         return salePostConverter.toSalePostDetailInfo(salePost, isMine);
     }
 
+    @Override
+    public PagedSalePostInfo fetchMySalePosts(Member loginMember, Pageable pageable) {
+        Member member = memberService.findMember(loginMember.getId());
+        return salePostConverter.toPagedSalePostList(
+                salePostRepository.findByMemberId(member.getId(),pageable)
+        );
+    }
+
 
     @Override
     public SalePost findSalePost(Long salePostId) {

--- a/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/service/SalePostServiceImpl.java
@@ -105,10 +105,10 @@ public class SalePostServiceImpl implements SalePostService {
     }
 
     @Override
-    public PagedSalePostInfo fetchMySalePosts(Member loginMember, Pageable pageable) {
+    public PagedSalePostInfo fetchMySalePosts(Member loginMember, boolean total, Pageable pageable) {
         Member member = memberService.findMember(loginMember.getId());
         return salePostConverter.toPagedSalePostList(
-                salePostRepository.findByMemberId(member.getId(),pageable)
+                salePostRepository.findByMemberId(member.getId(), total, pageable)
         );
     }
 

--- a/src/main/java/com/example/turnpage/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/turnpage/global/config/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
                         .requestMatchers("/error/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/books/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/salePosts/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/salePosts/my").hasRole("USER")
                         .requestMatchers(HttpMethod.GET, "/comments").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/test/java/com/example/turnpage/domain/salePost/controller/SalePostControllerTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/controller/SalePostControllerTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -163,7 +164,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .isLast(false)
                 .build();
 
-        given(salePostService.fetchSalePosts(any(),any())).willReturn(response);
+        given(salePostService.fetchSalePosts(anyBoolean(),any())).willReturn(response);
 
         //when
         ResultActions resultActions = mockMvc.perform(
@@ -178,7 +179,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.data.totalElements").value(1))
         ;
 
-        verify(salePostService).fetchSalePosts(any(),any());
+        verify(salePostService).fetchSalePosts(anyBoolean(),any());
     }
 
     @Test
@@ -195,7 +196,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .isLast(false)
                 .build();
 
-        given(salePostService.searchSalePost(any(),any(),any())).willReturn(response);
+        given(salePostService.searchSalePost(anyBoolean(),any(),any())).willReturn(response);
 
         //when
         ResultActions resultActions = mockMvc.perform(
@@ -212,7 +213,7 @@ public class SalePostControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.data.totalElements").value(1))
         ;
 
-        verify(salePostService).searchSalePost(any(), any(), any());
+        verify(salePostService).searchSalePost(anyBoolean(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
@@ -301,7 +301,7 @@ public class SalePostServiceTest extends ServiceTestConfig {
         assertEquals("꿈꾸지 않아도 빤짝이는 중 - 놀면서 일하는 두 남자 삐까뚱씨, 내일의 목표보단 오늘의 행복에 집중하는 인생로그",
                 detailInfo.getBookInfo().getTitle());
         assertEquals("수밈", detailInfo.getMemberInfo().getName());
-        assertEquals(true, detailInfo.isMine());
+        assertEquals(true, detailInfo.getIsMine());
     }
 
     @Test
@@ -313,9 +313,20 @@ public class SalePostServiceTest extends ServiceTestConfig {
         SalePostDetailInfo detailInfo = salePostService.getSalePostDetailInfo(null,testSalePost.getId());
 
         //then
-        assertEquals(false, detailInfo.isMine());
+        assertEquals(false, detailInfo.getIsMine());
     }
 
+    @Test
+    @Transactional
+    @DisplayName("내 판매글 목록 조회 성공 테스트")
+    public void fetchMySalePost() {
 
+        //given & when
+        Pageable pageable = PageRequest.of(0, 20);
+        PagedSalePostInfo mySalePostList = salePostService.fetchMySalePosts(testMember, pageable);
+
+        //then
+        assertEquals(1, mySalePostList.getTotalElements());
+    }
 
 }

--- a/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
+++ b/src/test/java/com/example/turnpage/domain/salePost/service/SalePostServiceTest.java
@@ -322,11 +322,18 @@ public class SalePostServiceTest extends ServiceTestConfig {
     public void fetchMySalePost() {
 
         //given & when
-        Pageable pageable = PageRequest.of(0, 20);
-        PagedSalePostInfo mySalePostList = salePostService.fetchMySalePosts(testMember, pageable);
+        testSalePost.setSold();
 
+        Pageable pageable = PageRequest.of(0, 20);
+        PagedSalePostInfo mySalePostList = salePostService.fetchMySalePosts(testMember, true, pageable);
         //then
         assertEquals(1, mySalePostList.getTotalElements());
+
+        //when
+        testSalePost.setSold();
+        PagedSalePostInfo mySalePostList2 = salePostService.fetchMySalePosts(testMember, false, pageable);
+        assertEquals(0, mySalePostList2.getTotalElements());
+
     }
 
 }


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #65 

## 📝 작업 내용
 내 판매글 조회 API를 구현하였습니다.
 또 주문 시 member saleCount, purchaseCount가 각각 증가하도록 수정하고, 독후감 작성, 삭제시 reportCount 증가, 삭제 되도록 수정하였습니다.
## 💭 주의 사항

## 💡 리뷰 포인트
서비스 테스트 완료하였습니다!