### PR TITLE
[FIX]판매글 decription 5000자 제한으로 수정

### DIFF
--- a/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostRequest.java
+++ b/src/main/java/com/example/turnpage/domain/salePost/dto/SalePostRequest.java
@@ -18,7 +18,7 @@ public abstract class SalePostRequest {
         @Size(max = 30)
         @NotEmpty
         private String title;
-        @Size(max = 1000)
+        @Size(max = 5000)
         @NotEmpty
         private String description;
         @NotBlank
@@ -36,7 +36,7 @@ public abstract class SalePostRequest {
         @Size(max = 30)
         @NotEmpty
         private String title;
-        @Size(max = 1000)
+        @Size(max = 5000)
         @NotEmpty
         private String description;
         @NotBlank


### PR DESCRIPTION
## ❗️ 이슈 번호

## 📝 작업 내용
판매글 description을 1000자 -> 5000자 제한으로 변경하였습니다.
## 💭 주의 사항

## 💡 리뷰 포인트
