### PR TITLE
[Chore, Fix] logback 설정, bestSeller 조회 로직 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 application.yml
+logs

--- a/src/main/java/com/example/turnpage/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/example/turnpage/domain/book/repository/BookRepository.java
@@ -20,12 +20,10 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     //띄어쓰기 무시하고 검색하기
      @Query("SELECT b FROM Book b WHERE REPLACE(b.title, ' ', '') LIKE %:keyword% OR REPLACE(b.author, ' ', '') LIKE %:keyword%")
     Page<Book> findByTitleOrAuthorContaining(@Param("keyword") String keyword, Pageable pageable);
-    @Modifying
+
+     @Modifying
     @Query("UPDATE Book b SET b.ranking = null WHERE b.ranking IS NOT NULL")
     void updateRankToNull();
-
-    @Query("SELECT b.itemId FROM Book b WHERE b.ranking IS NOT NULL")
-    List<Long> findAllItemIdByRankingNotNull();
 
     Optional<Book> findByItemId(Long itemId);
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+
+    <property name="CONSOLE_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %highlight([%-3level]) %logger{5} - %msg %n" />
+    <property name="ROLLING_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS}  %logger{5} - %msg %n" />
+    <property name="LOG_NAME_PATTERN" value="./logs/turnpage-%d{yyyy-MM-dd}.%i.log" />
+    <property name="MAX_FILE_SIZE" value="10MB" />
+    <property name="TOTAL_SIZE" value="310MB" />
+    <property name="MAX_HISTORY" value="31" />
+
+
+    <!-- Console appender 설정 -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+
+
+    <appender name="ROLLING_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${ROLLING_PATTERN}</pattern>
+        </encoder>
+        <file>${FILE_NAME}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_NAME_PATTERN}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+            <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
+            <totalSizeCap>${TOTAL_SIZE}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="jdbc" level="OFF" additive="false">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROLLING_LOG_FILE"/>
+    </logger>
+    <logger name="jdbc.sqlonly" level="DEBUG" additive="false" >
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROLLING_LOG_FILE"/>
+    </logger>
+    <logger name="jdbc.sqltiming" level="OFF" additive="false" >
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROLLING_LOG_FILE"/>
+    </logger>
+    <logger name="org.hibernate.SQL" level="DEBUG" additive="false">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROLLING_LOG_FILE"/>
+    </logger>
+    <logger name="com.example.todolist.controller" level="INFO" additive="true" >
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROLLING_LOG_FILE"/>
+    </logger>
+    <logger name="com.example.todolist.service" level="DEBUG" additive="false" >
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROLLING_LOG_FILE"/>
+    </logger>
+    <logger name="com.example.todolist.domain" level="DEBUG" additive="false" >
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROLLING_LOG_FILE"/>
+    </logger>
+
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ROLLING_LOG_FILE"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -30,37 +30,24 @@
         </rollingPolicy>
     </appender>
 
-    <logger name="jdbc" level="OFF" additive="false">
+    <logger name="jdbc" level="OFF" additivity="false">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ROLLING_LOG_FILE"/>
     </logger>
-    <logger name="jdbc.sqlonly" level="DEBUG" additive="false" >
+    <logger name="jdbc.sqlonly" level="DEBUG" additivity = "false" >
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ROLLING_LOG_FILE"/>
     </logger>
-    <logger name="jdbc.sqltiming" level="OFF" additive="false" >
+    <logger name="jdbc.sqltiming" level="OFF" additivity = "false" >
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ROLLING_LOG_FILE"/>
     </logger>
-    <logger name="org.hibernate.SQL" level="DEBUG" additive="false">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="ROLLING_LOG_FILE"/>
-    </logger>
-    <logger name="com.example.todolist.controller" level="INFO" additive="true" >
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="ROLLING_LOG_FILE"/>
-    </logger>
-    <logger name="com.example.todolist.service" level="DEBUG" additive="false" >
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="ROLLING_LOG_FILE"/>
-    </logger>
-    <logger name="com.example.todolist.domain" level="DEBUG" additive="false" >
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity = "false">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ROLLING_LOG_FILE"/>
     </logger>
 
-
-    <root level="INFO">
+    <root level="INFO" additivity = "false">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ROLLING_LOG_FILE"/>
     </root>


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #71

## 📝 작업 내용
* 로그백 설정을 통해, 매일  logs 폴더에 로그파일 저장하도록 하였습니다. 최대 31개의 파일만 저장하고, 기간이 지난 로그파일들은 삭제되도록 하였습니다.
* bestseller에서 더이상 베스트셀러가 아니게 된 책의 랭킹을 null로 설정하도록 수정하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트
